### PR TITLE
refresh git index before checking

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -28,6 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd gh-pages
+          git update-index -q --refresh
           git diff-index --quiet HEAD && exit 0 # commit only if something to do
           git config --local user.email "ci@github.io"
           git config --local user.name "Update CI"


### PR DESCRIPTION
same as what is in https://github.com/sonatype-nexus-community/pytorch-pypi/blob/main/update-pytorch.sh#L106
will avoid "false positive" CI run failure